### PR TITLE
Pseudorandomized space for smoke tests

### DIFF
--- a/jobs/smoke-tests/templates/run
+++ b/jobs/smoke-tests/templates/run
@@ -12,7 +12,7 @@ source /var/vcap/jobs/smoke-tests/env
 
 mkdir /var/vcap/jobs/smoke-tests/.cf
 export CF_HOME=/var/vcap/jobs/smoke-tests/.cf
-export CF_SPACE="scheduler-smoke-tests-$(date +%s)"
+export CF_SPACE="scheduler-smoke-tests-$(date +"%Y-%m-%dT%H:%M:%S")"
 
 ## SETUP
 

--- a/jobs/smoke-tests/templates/run
+++ b/jobs/smoke-tests/templates/run
@@ -12,7 +12,7 @@ source /var/vcap/jobs/smoke-tests/env
 
 mkdir /var/vcap/jobs/smoke-tests/.cf
 export CF_HOME=/var/vcap/jobs/smoke-tests/.cf
-export MYSPACE="scheduler-smoke-tests-$(date +%s)"
+export CF_SPACE="scheduler-smoke-tests-$(date +%s)"
 
 ## SETUP
 
@@ -27,11 +27,11 @@ cf auth "${CF_USERNAME}" "${CF_PASSWORD}"
 cf target -o "${CF_ORGANIZATION}"
 
 # create space
-cf create-space "${MYSPACE}" -o "${CF_ORGANIZATION}"
+cf create-space "${CF_SPACE}" -o "${CF_ORGANIZATION}"
 
 # target space
 
-cf target -s "${MYSPACE}"
+cf target -s "${CF_SPACE}"
 
 ## TESTS
 
@@ -57,4 +57,4 @@ go test -timeout 600s ./...
 
 # delete space
 
-cf delete-space "${MYSPACE}" -o "${CF_ORGANIZATION}" -f
+cf delete-space "${CF_SPACE}" -o "${CF_ORGANIZATION}" -f

--- a/jobs/smoke-tests/templates/run
+++ b/jobs/smoke-tests/templates/run
@@ -12,8 +12,30 @@ source /var/vcap/jobs/smoke-tests/env
 
 mkdir /var/vcap/jobs/smoke-tests/.cf
 export CF_HOME=/var/vcap/jobs/smoke-tests/.cf
+export MYSPACE="scheduler-smoke-tests-$(date +%s)"
 
-cf login -a "$CF_ENDPOINT" -u "$CF_USERNAME" -p "$CF_PASSWORD" -o "$CF_ORGANIZATION" -s "$CF_SPACE" --skip-ssl-validation
+## SETUP
+
+# set the API
+cf api "${CF_ENDPOINT}" --skip-ssl-validation
+
+# do auth
+cf auth "${CF_USERNAME}" "${CF_PASSWORD}"
+
+# target org
+
+cf target -o "${CF_ORGANIZATION}"
+
+# create space
+cf create-space "${MYSPACE}" -o "${CF_ORGANIZATION}"
+
+# target space
+
+cf target -s "${MYSPACE}"
+
+## TESTS
+
+#cf login -a "$CF_ENDPOINT" -u "$CF_USERNAME" -p "$CF_PASSWORD" -o "$CF_ORGANIZATION" -s "$CF_SPACE" --skip-ssl-validation
 
 echo "==="
 echo "Setting up CF CLI plugin..."
@@ -29,3 +51,10 @@ echo "==="
 echo "Running all acceptance tests..."
 cd /var/vcap/packages/smoke-tests
 go test -timeout 600s ./...
+
+
+## TEARDOWN
+
+# delete space
+
+cf delete-space "${MYSPACE}" -o "${CF_ORGANIZATION}" -f


### PR DESCRIPTION
As we can't really rely on the incoming space to be present on
the foundation, instead we're creating a datestamped space for
each smoke tests invocation.

This space is used exclusively for the smoke tests and is deleted
after the test run finishes.